### PR TITLE
バグ修正

### DIFF
--- a/app/controllers/chronologies_controller.rb
+++ b/app/controllers/chronologies_controller.rb
@@ -22,6 +22,7 @@ class ChronologiesController < ApplicationController
   end
 
   def show
+    redirect_to chronologies_path
   end
 
   def edit

--- a/app/controllers/chronologies_controller.rb
+++ b/app/controllers/chronologies_controller.rb
@@ -5,7 +5,7 @@ class ChronologiesController < ApplicationController
   
   def index
     @q = Chronology.ransack(params[:q])
-    @chronologies = @q.result(distinct: true).order(:chapter).page(params[:page]).per(10)
+    @chronologies = @q.result(distinct: true).order(:year).page(params[:page]).per(10)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    redirect_to users_path
+  end
+
   def edit
   end
 

--- a/app/views/chronologies/show.html.erb
+++ b/app/views/chronologies/show.html.erb
@@ -1,2 +1,0 @@
-<h1>Chronologies#show</h1>
-<p>Find me in app/views/chronologies/show.html.erb</p>

--- a/app/views/episodes/edit.html.erb
+++ b/app/views/episodes/edit.html.erb
@@ -38,7 +38,7 @@
     <div class="row">
       <div class="input-field col s6">
         <%= f.label :tag_list, 'タグ', class: 'active' %>
-        <%= f.text_field :tag_list, class: 'validate' %>
+        <%= f.text_field :tag_list, value: @episode.tag_list.join(','), class: 'validate' %>
       </div>
       <div class="input-field col s6">
         <%= f.label :keyitem, 'キーアイテム', class: 'active' %>


### PR DESCRIPTION
## WHAT
- 年表の一覧画面が表示されない問題の修正
- 年表、ユーザーのshowアクションが呼び出されたら一覧画面にリダイレクトする
- エピソードの編集時にタグのカンマが消えないようにする